### PR TITLE
Migrate to TCA 1.7.0 and implement new Perception observing mechanisms

### DIFF
--- a/Targets/App/Sources/SwiftUpApp.swift
+++ b/Targets/App/Sources/SwiftUpApp.swift
@@ -6,14 +6,16 @@ import SwiftUI
 struct SwiftUpApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
-    let store: StoreOf<SplashFeature> = .init(initialState: SplashFeature.State(), reducer: SplashFeature.init)
+    @Perception.Bindable var store: StoreOf<SplashFeature> = .init(initialState: SplashFeature.State(), reducer: SplashFeature.init)
 
     /// Please refer to `Testing Gotchas section` of:
     ///  https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/testing
     var body: some Scene {
-        WindowGroup {
-            if !_XCTIsTesting {
-                SplashView(store: store)
+        WithPerceptionTracking {
+            WindowGroup {
+                if !_XCTIsTesting {
+                    SplashView(store: store)
+                }
             }
         }
     }

--- a/Targets/Core/SwiftUpUI/Sources/Cells/Conference/ConferenceItemFeature.swift
+++ b/Targets/Core/SwiftUpUI/Sources/Cells/Conference/ConferenceItemFeature.swift
@@ -3,8 +3,9 @@ import Foundation
 import SwiftUpKit
 
 @Reducer
-public struct ConferenceItemFeature {
-    public struct State: Equatable {
+public struct ConferenceItemFeature: Reducer {
+    @ObservableState
+    public struct State: Equatable, Identifiable {
         public let id: UUID
         public let name: String
         public let imageURL: URL
@@ -16,9 +17,11 @@ public struct ConferenceItemFeature {
             self.imageURL = conference.imageURL
             self.city = conference.city
         }
+        
+        public static let mock: Self = .init(conference: .mock)
     }
     
-    public enum Action {
+    public enum Action: Equatable {
         case didSelectConference
     }
     
@@ -30,4 +33,6 @@ public struct ConferenceItemFeature {
             }
         }
     }
+    
+    public init() {}
 }

--- a/Targets/Core/SwiftUpUI/Sources/Cells/Conference/ConferenceItemView.swift
+++ b/Targets/Core/SwiftUpUI/Sources/Cells/Conference/ConferenceItemView.swift
@@ -2,31 +2,31 @@ import ComposableArchitecture
 import SwiftUI
 
 public struct ConferenceItemView: View {
-    private let store: StoreOf<ConferenceItemFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<ConferenceItemFeature>
+    @Perception.Bindable private var store: StoreOf<ConferenceItemFeature>
     
     public init(store: StoreOf<ConferenceItemFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
  
     public var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                AsyncImage(url: viewStore.imageURL)
-                    .frame(width: 50, height: 50)
-                    .clipShape(Circle())
-                Text(viewStore.name)
-                    .font(.title)
-                    .bold()
-                    
-                Spacer()
+        WithPerceptionTracking {
+            VStack(alignment: .leading) {
+                HStack {
+                    AsyncImage(url: store.imageURL)
+                        .frame(width: 50, height: 50)
+                        .clipShape(Circle())
+                    Text(store.name)
+                        .font(.title)
+                        .bold()
+                        
+                    Spacer()
+                }
+                
+                locationTag(name: store.city)
             }
-            
-            locationTag(name: viewStore.city)
-        }
-        .onTapGesture {
-            viewStore.send(.didSelectConference)
+            .onTapGesture {
+                store.send(.didSelectConference)
+            }
         }
     }
     

--- a/Targets/Core/SwiftUpUI/Sources/Cells/Event/EventFeature.swift
+++ b/Targets/Core/SwiftUpUI/Sources/Cells/Event/EventFeature.swift
@@ -1,0 +1,58 @@
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+public struct EventFeature: Reducer {
+    @ObservableState
+    public enum State: Identifiable, Equatable {
+        case meetup(MeetupItemFeature.State)
+        case conference(ConferenceItemFeature.State)
+        
+        public var id: UUID {
+            switch self {
+            case .meetup(let meetup):
+                return meetup.id
+            case .conference(let conference):
+                return conference.id
+            }
+        }
+        
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.meetup(let lhs), .meetup(let rhs)):
+                return lhs.id == rhs.id
+            case (.conference(let lhs), .conference(let rhs)):
+                return lhs.id == rhs.id
+            default:
+                return false
+            }
+        }
+    }
+    
+    public enum Action {
+        case onAppear
+        case meetup(MeetupItemFeature.Action)
+        case conference(ConferenceItemFeature.Action)
+    }
+    
+    public var body: some ReducerOf<Self> {
+        Reduce { _, _ in
+            return .none
+        }
+        .ifCaseLet(\.meetup, action: \.meetup) {
+            MeetupItemFeature()
+        }
+        .ifCaseLet(\.conference, action: \.conference) {
+            ConferenceItemFeature()
+        }
+    }
+    
+    public init() {}
+}
+
+public extension IdentifiedArray where Element == EventFeature.State, ID == UUID {
+    static var mock: Self = [
+        .meetup(.mock),
+        .conference(.mock)
+    ]
+}

--- a/Targets/Core/SwiftUpUI/Sources/Cells/Meetup/MeetupItemFeature.swift
+++ b/Targets/Core/SwiftUpUI/Sources/Cells/Meetup/MeetupItemFeature.swift
@@ -2,7 +2,9 @@ import ComposableArchitecture
 import Foundation
 import SwiftUpKit
 
+@Reducer
 public struct MeetupItemFeature: Reducer {
+    @ObservableState
     public struct State: Equatable, Identifiable {
         public let id: UUID
         public let title: String
@@ -17,6 +19,8 @@ public struct MeetupItemFeature: Reducer {
             self.tags = meetup.tags
             self.city = meetup.city
         }
+        
+        public static let mock: Self = .init(meetup: .mock)
     }
     
     public enum Action: Equatable {
@@ -38,10 +42,5 @@ public struct MeetupItemFeature: Reducer {
         }
     }
     
-    public init () {}
-}
-
-public extension MeetupItemFeature.State {
-    static let mock: Self = .init(
-        meetup: .mock)
+    public init() {}
 }

--- a/Targets/Core/SwiftUpUI/Sources/Cells/Meetup/MeetupItemView.swift
+++ b/Targets/Core/SwiftUpUI/Sources/Cells/Meetup/MeetupItemView.swift
@@ -2,58 +2,58 @@ import ComposableArchitecture
 import SwiftUI
 
 public struct MeetupItemView: View {
-    private let store: StoreOf<MeetupItemFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<MeetupItemFeature>
+    @Perception.Bindable private var store: StoreOf<MeetupItemFeature>
     
     public init(store: StoreOf<MeetupItemFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
     
     public var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            location
-            
-            Text(viewStore.title)
-                .font(.title3)
-                .foregroundStyle(.primary)
-                .bold()
-            
-            Text(viewStore.description)
-                .foregroundStyle(.secondary)
-                .padding(.bottom, 5)
-            
-            ScrollView(.horizontal) {
-                HStack {
-                    ForEach(viewStore.tags, id: \.self) { tag in
-                        Text(tag)
-                            .fontWeight(.heavy)
-                            .foregroundStyle(.white)
-                            .padding(.vertical, 6)
-                            .padding(.horizontal, 8)
-                            .background {
-                                Color.blue
-                            }
-                            .frame(height: 25)
-                            .cornerRadius(5)
+        WithPerceptionTracking {
+            VStack(alignment: .leading, spacing: 6) {
+                location
+                
+                Text(store.title)
+                    .font(.title3)
+                    .foregroundStyle(.primary)
+                    .bold()
+                
+                Text(store.description)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 5)
+                
+                ScrollView(.horizontal) {
+                    HStack {
+                        ForEach(store.tags, id: \.self) { tag in
+                            Text(tag)
+                                .fontWeight(.heavy)
+                                .foregroundStyle(.white)
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 8)
+                                .background {
+                                    Color.blue
+                                }
+                                .frame(height: 25)
+                                .cornerRadius(5)
+                        }
                     }
                 }
             }
-        }
-        .onTapGesture { viewStore.send(.didSelectMeetup) }
-        .swipeActions(edge: .trailing) {
-            Button(
-                action: { viewStore.send(.didSelectShare)},
-                label: {
-                    Image(systemName: "square.and.arrow.up.fill")
-                })
-            .tint(.blue)
-            Button(
-                action: { viewStore.send(.didSelectSave)}, 
-                label: {
-                    Image(systemName: "bookmark.fill")
-                })
-            .tint(.orange)
+            .onTapGesture { store.send(.didSelectMeetup) }
+            .swipeActions(edge: .trailing) {
+                Button(
+                    action: { store.send(.didSelectShare)},
+                    label: {
+                        Image(systemName: "square.and.arrow.up.fill")
+                    })
+                .tint(.blue)
+                Button(
+                    action: { store.send(.didSelectSave)},
+                    label: {
+                        Image(systemName: "bookmark.fill")
+                    })
+                .tint(.orange)
+            }
         }
     }
     
@@ -61,7 +61,7 @@ public struct MeetupItemView: View {
     private var location: some View {
         HStack(spacing: 4) {
             Image(systemName: "mappin.and.ellipse")
-            Text(viewStore.city)
+            Text(store.city)
         }
         .font(.footnote)
         .foregroundStyle(.secondary)

--- a/Targets/Core/SwiftUpUI/Sources/SwiftUISupport/AppearanceGroup.swift
+++ b/Targets/Core/SwiftUpUI/Sources/SwiftUISupport/AppearanceGroup.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ComposableArchitecture
 
 public struct AppearanceGroup<Content: View>: View {
     private let content: Content
@@ -8,14 +9,16 @@ public struct AppearanceGroup<Content: View>: View {
     }
     
     public var body: some View {
-        Group {
-            content
-                .preferredColorScheme(.light)
-                .previewDisplayName("Light Mode")
-            
-            content
-                .preferredColorScheme(.dark)
-                .previewDisplayName("Dark Mode")
+        WithPerceptionTracking {
+            Group {
+                content
+                    .preferredColorScheme(.light)
+                    .previewDisplayName("Light Mode")
+                
+                content
+                    .preferredColorScheme(.dark)
+                    .previewDisplayName("Dark Mode")
+            }
         }
     }
 }

--- a/Targets/Feature/Dashboard/Sources/DashboardView.swift
+++ b/Targets/Feature/Dashboard/Sources/DashboardView.swift
@@ -2,16 +2,16 @@ import ComposableArchitecture
 import SwiftUI
 
 public struct DashboardView: View {
-    private let store: StoreOf<DashboardFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<DashboardFeature>
+    @Perception.Bindable private var store: StoreOf<DashboardFeature>
     
     public init(store: StoreOf<DashboardFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
     
     public var body: some View {
-        Image(systemName: "bookmark")
+        WithPerceptionTracking {
+            Image(systemName: "bookmark")
+        }
     }
 }
 

--- a/Targets/Feature/Events/Sources/EventsFeature.swift
+++ b/Targets/Feature/Events/Sources/EventsFeature.swift
@@ -1,15 +1,32 @@
 import ComposableArchitecture
+import SwiftUpUI
 
 @Reducer
 public struct EventsFeature: Reducer {
+    @ObservableState
     public struct State: Equatable {
+        var events: IdentifiedArrayOf<EventFeature.State> = .mock
+        
         public init() {}
     }
-    
-    public enum Action {}
+
+    public enum Action {
+        case onAppear
+        case events(IdentifiedActionOf<EventFeature>)
+    }
     
     public var body: some ReducerOf<Self> {
-        EmptyReducer()
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return .none
+            case let .events(.element(id, action)):
+                return .none
+            }
+        }
+        .forEach(\.events, action: \.events) {
+            EventFeature()
+        }
     }
     
     public init() {}

--- a/Targets/Feature/Events/Sources/EventsView.swift
+++ b/Targets/Feature/Events/Sources/EventsView.swift
@@ -1,17 +1,31 @@
 import ComposableArchitecture
 import SwiftUI
+import SwiftUpUI
 
 public struct EventsView: View {
-    private let store: StoreOf<EventsFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<EventsFeature>
+    @Perception.Bindable private var store: StoreOf<EventsFeature>
     
     public init(store: StoreOf<EventsFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
     
     public var body: some View {
-        Image(systemName: "calendar")
+        WithPerceptionTracking {
+            List {
+                ForEach(store.scope(state: \.events, action: \.events)) { childStore in
+                    switch childStore.state {
+                    case .conference:
+                        if let scopedStore = childStore.scope(state: \.conference, action: \.conference) {
+                            ConferenceItemView(store: scopedStore)
+                        }
+                    case .meetup:
+                        if let scopedStore = childStore.scope(state: \.meetup, action: \.meetup) {
+                            MeetupItemView(store: scopedStore)
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Targets/Feature/Settings/Sources/SettingsView.swift
+++ b/Targets/Feature/Settings/Sources/SettingsView.swift
@@ -2,16 +2,16 @@ import ComposableArchitecture
 import SwiftUI
 
 public struct SettingsView: View {
-    private let store: StoreOf<SettingsFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<SettingsFeature>
+    @Perception.Bindable private var store: StoreOf<SettingsFeature>
     
     public init(store: StoreOf<SettingsFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
     
     public var body: some View {
-        Image(systemName: "gear")
+        WithPerceptionTracking {
+            Image(systemName: "gear")
+        }
     }
 }
 

--- a/Targets/Feature/Speakers/Sources/SpeakersView.swift
+++ b/Targets/Feature/Speakers/Sources/SpeakersView.swift
@@ -2,16 +2,16 @@ import ComposableArchitecture
 import SwiftUI
 
 public struct SpeakersView: View {
-    private let store: StoreOf<SpeakersFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<SpeakersFeature>
+    @Perception.Bindable private var store: StoreOf<SpeakersFeature>
     
     public init(store: StoreOf<SpeakersFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
     
     public var body: some View {
-        Image(systemName: "music.mic")
+        WithPerceptionTracking {
+            Image(systemName: "music.mic")
+        }
     }
 }
 

--- a/Targets/Feature/Splash/Sources/SplashFeature.swift
+++ b/Targets/Feature/Splash/Sources/SplashFeature.swift
@@ -3,6 +3,7 @@ import Tabs
 
 @Reducer
 public struct SplashFeature: Reducer {
+    @ObservableState
     public struct State: Equatable {
         var path = StackState<Path.State>()
         
@@ -40,7 +41,9 @@ public struct SplashFeature: Reducer {
 }
 
 extension SplashFeature {
+    @Reducer
     public struct Path: Reducer {
+        @ObservableState
         public enum State: Equatable {
             case tabs(TabsFeature.State = .init())
         }
@@ -50,7 +53,7 @@ extension SplashFeature {
         }
         
         public var body: some ReducerOf<Self> {
-            Scope(state: /State.tabs, action: /Action.tabs) {
+            Scope(state: \.tabs, action: \.tabs) {
                 TabsFeature()
             }
         }

--- a/Targets/Feature/Splash/Sources/SplashView.swift
+++ b/Targets/Feature/Splash/Sources/SplashView.swift
@@ -3,31 +3,31 @@ import SwiftUI
 import Tabs
 
 public struct SplashView: View {
-    private let store: StoreOf<SplashFeature>
-    @ObservedObject private var viewStore: ViewStoreOf<SplashFeature>
+    @Perception.Bindable private var store: StoreOf<SplashFeature>
     
     public init(store: StoreOf<SplashFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
     
     public var body: some View {
-        NavigationStackStore(store.scope(state: \.path, action: { .path($0) })) {
-            VStack {
-                Text("Splash")
+        WithPerceptionTracking {
+            NavigationStack(
+                path: $store.scope(state: \.path, action: \.path)
+            ) {
+                VStack {
+                    Text("Splash")
+                }
+            } destination: { store in
+                switch store.state {
+                case .tabs:
+                    if let scopedStore = store.scope(state: \.tabs, action: \.tabs) {
+                        TabsView(store: scopedStore)
+                    }
+                }
             }
-        } destination: { initialState in
-            switch initialState {
-            case .tabs:
-                CaseLet(
-                    /SplashFeature.Path.State.tabs,
-                     action: SplashFeature.Path.Action.tabs,
-                     then: TabsView.init
-                )
+            .onAppear {
+                store.send(.onAppear)
             }
-        }
-        .onAppear {
-            viewStore.send(.onAppear)
         }
     }
 }

--- a/Targets/Feature/Tabs/Sources/TabsFeature.swift
+++ b/Targets/Feature/Tabs/Sources/TabsFeature.swift
@@ -6,6 +6,7 @@ import Settings
 
 @Reducer
 public struct TabsFeature: Reducer {
+    @ObservableState
     public struct State: Equatable {
         var dashboard: DashboardFeature.State = .init()
         var events: EventsFeature.State = .init()
@@ -42,16 +43,16 @@ public struct TabsFeature: Reducer {
                 return .none
             }
         }
-        Scope(state: \.dashboard, action: /Action.dashboard) {
+        Scope(state: \.dashboard, action: \.dashboard) {
             DashboardFeature()
         }
-        Scope(state: \.events, action: /Action.events) {
+        Scope(state: \.events, action: \.events) {
             EventsFeature()
         }
-        Scope(state: \.speakers, action: /Action.speakers) {
+        Scope(state: \.speakers, action: \.speakers) {
             SpeakersFeature()
         }
-        Scope(state: \.settings, action: /Action.settings) {
+        Scope(state: \.settings, action: \.settings) {
             SettingsFeature()
         }
     }

--- a/Targets/Feature/Tabs/Sources/TabsView.swift
+++ b/Targets/Feature/Tabs/Sources/TabsView.swift
@@ -6,43 +6,33 @@ import Settings
 import SwiftUI
 
 public struct TabsView: View {
-    private let store: StoreOf<TabsFeature>
-    @ObservedObject var viewStore: ViewStoreOf<TabsFeature>
+    @Perception.Bindable private var store: StoreOf<TabsFeature>
 
     public init(store: StoreOf<TabsFeature>) {
         self.store = store
-        self.viewStore = ViewStore(store, observe: { $0 })
     }
 
     public var body: some View {
-        TabView(selection: viewStore.binding(
-            get: { $0.activeTab },
-            send: TabsFeature.Action.didSelectTab)) {
-                DashboardView(store: store.scope(
-                    state: \.dashboard,
-                    action: TabsFeature.Action.dashboard))
-                    .tabItem { Image(systemName: "bookmark") }
-                    .tag(Tab.dashboard)
-                
-                EventsView(store: store.scope(
-                    state: \.events,
-                    action: TabsFeature.Action.events))
-                    .tabItem { Image(systemName: "calendar") }
-                    .tag(Tab.events)
-                
-                SpeakersView(store: store.scope(
-                    state: \.speakers,
-                    action: TabsFeature.Action.speakers))
-                    .tabItem { Image(systemName: "music.mic") }
-                    .tag(Tab.speakers)
-                
-                SettingsView(store: store.scope(
-                    state: \.settings,
-                    action: TabsFeature.Action.settings))
-                    .tabItem { Image(systemName: "gear") }
-                    .tag(Tab.settings)
-            }
-            .toolbar(.hidden)
+        WithPerceptionTracking {
+            TabView(selection: $store.activeTab.sending(\.didSelectTab)) {
+                    DashboardView(store: store.scope(state: \.dashboard, action: \.dashboard))
+                        .tabItem { Image(systemName: "bookmark") }
+                        .tag(Tab.dashboard)
+                    
+                    EventsView(store: store.scope(state: \.events, action: \.events))
+                        .tabItem { Image(systemName: "calendar") }
+                        .tag(Tab.events)
+                    
+                    SpeakersView(store: store.scope(state: \.speakers, action: \.speakers))
+                        .tabItem { Image(systemName: "music.mic") }
+                        .tag(Tab.speakers)
+                    
+                    SettingsView(store: store.scope(state: \.settings, action: \.settings))
+                        .tabItem { Image(systemName: "gear") }
+                        .tag(Tab.settings)
+                }
+                .toolbar(.hidden)
+        }
     }
 }
 

--- a/Tuist/ProjectDescriptionHelpers/ThirdParty.swift
+++ b/Tuist/ProjectDescriptionHelpers/ThirdParty.swift
@@ -15,7 +15,7 @@ public enum ThirdParty: CaseIterable {
         case .composableArchitecture:
             return .remote(
                 url: "https://github.com/pointfreeco/swift-composable-architecture",
-                requirement: .upToNextMajor(from: "1.5.6")
+                requirement: .upToNextMajor(from: "1.7.0")
             )
         }
     }


### PR DESCRIPTION
Migrate the codebase to TCA 1.7.0 and take advantage of the new Perception observing mechanisms. This update includes changes to the `SettingsView`, `SpeakersView`, `DashboardView`, `SplashFeature`, `MeetupItemFeature`, `ConferenceItemFeature`, `EventsFeature`, `SwiftUpApp`, `AppearanceGroup`, `TabsFeature`, and `EventsView` files.

Closes #28